### PR TITLE
2.9.2

### DIFF
--- a/chunks.html
+++ b/chunks.html
@@ -121,6 +121,19 @@
         word-break: break-word;
       }
 
+      /* Support for inline styled spans */
+      .markdown-content span {
+        display: inline;
+      }
+
+      .markdown-content span[style*="font-style:italic"] {
+        font-style: italic;
+      }
+
+      .markdown-content span[style*="font-size"] {
+        /* Allow inline font-size styles to be applied */
+      }
+
       .markdown-content code,
       .markdown-content pre {
         font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Courier New', monospace;

--- a/chunks.js
+++ b/chunks.js
@@ -539,7 +539,7 @@ function createPartContent(content, isActive, partIndex) {
     // Sanitize the HTML content directly instead of parsing as markdown
     partContent.innerHTML = DOMPurify.sanitize(htmlContent, {
       ALLOWED_TAGS: ['img', 'p', 'br', 'strong', 'em', 'b', 'i', 'u', 'a', 'div', 'span'],
-      ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style']
+      ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style', 'font-style', 'font-size']
     });
     
     // Ensure images are displayed properly
@@ -1213,10 +1213,10 @@ async function updateStreamingChunk(content, rawContent, isInitial = false, isCo
         const partContent = chunkDiv.querySelector('.part-content.active');
         if (partContent) {
           // Check if content contains HTML (like images)
-          if (content.includes('<img') || content.includes('<br') || content.includes('<p>')) {
+          if (content.includes('<img') || content.includes('<br') || content.includes('<p>') || content.includes('<span')) {
             partContent.innerHTML = DOMPurify.sanitize(content, {
               ALLOWED_TAGS: ['img', 'p', 'br', 'strong', 'em', 'b', 'i', 'u', 'a', 'div', 'span'],
-              ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style']
+              ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style', 'font-style', 'font-size']
             });
             
             // Ensure images are displayed properly with .file handling
@@ -1354,11 +1354,11 @@ async function updateStreamingChunk(content, rawContent, isInitial = false, isCo
       partContentElement.className = 'markdown-content part-content active';
       partContentElement.dataset.part = '0';
       
-      // Handle HTML content with images
-      if (content.includes('<img') || content.includes('<br') || content.includes('<p>')) {
+      // Handle HTML content with images and spans
+      if (content.includes('<img') || content.includes('<br') || content.includes('<p>') || content.includes('<span')) {
         partContentElement.innerHTML = DOMPurify.sanitize(content, {
           ALLOWED_TAGS: ['img', 'p', 'br', 'strong', 'em', 'b', 'i', 'u', 'a', 'div', 'span'],
-          ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style']
+          ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style', 'font-style', 'font-size']
         });
         
         // Ensure images are displayed properly
@@ -1442,11 +1442,11 @@ async function updateStreamingChunk(content, rawContent, isInitial = false, isCo
     } else { // Update existing chunk content
       const partContent = chunkDiv.querySelector('.part-content.active');
       if (partContent) {
-        // Handle HTML content with images during streaming
-        if (content.includes('<img') || content.includes('<br') || content.includes('<p>')) {
+        // Handle HTML content with images and spans during streaming
+        if (content.includes('<img') || content.includes('<br') || content.includes('<p>') || content.includes('<span')) {
           partContent.innerHTML = DOMPurify.sanitize(content, {
             ALLOWED_TAGS: ['img', 'p', 'br', 'strong', 'em', 'b', 'i', 'u', 'a', 'div', 'span'],
-            ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style']
+            ALLOWED_ATTR: ['src', 'alt', 'title', 'href', 'class', 'style', 'font-style', 'font-size']
           });
           
           // Ensure images are displayed properly with .file handling

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {  "manifest_version": 2,
-  "name": "AI Webnovel Translator",
-  "version": "2.9.1",
+  "name": "AI Webnovel Translator Experimental",
+  "version": "2.9.2",
   "description": "Extracts text chunks from syosetsu/kakyomu/fortuneeternal/booktoki paragraphs, translates them using gemini flash (BRING YOUR OWN GEMINI API KEY [It's FREE on Google's AI Studio]) or Vertex AI (BRING YOUR OWN GOOGLE CLOUD SERVICE ACCOUNT KEY IN JSON) or OpenRouter or OpenAI and displays them in a new page.",
   "permissions": [
     "activeTab",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {  "manifest_version": 2,
-  "name": "AI Webnovel Translator Experimental",
+  "name": "AI Webnovel Translator",
   "version": "2.9.2",
   "description": "Extracts text chunks from syosetsu/kakyomu/fortuneeternal/booktoki paragraphs, translates them using gemini flash (BRING YOUR OWN GEMINI API KEY [It's FREE on Google's AI Studio]) or Vertex AI (BRING YOUR OWN GOOGLE CLOUD SERVICE ACCOUNT KEY IN JSON) or OpenRouter or OpenAI and displays them in a new page.",
   "permissions": [


### PR DESCRIPTION
This pull request adds support for inline styled `span` elements in markdown-rendered content, allowing for custom font styles and sizes to be preserved and displayed. The changes update both the CSS and the HTML sanitization logic to ensure that `span` tags with style attributes are properly handled and rendered. The version number in `manifest.json` is also incremented to reflect the update.

**Support for inline styled spans in markdown output:**

* Updated `.markdown-content` CSS in `chunks.html` to support inline `span` tags and apply `font-style: italic` when specified.

**Sanitization and rendering improvements:**

* Modified DOMPurify sanitization in `chunks.js` to allow `font-style` and `font-size` attributes on `span` tags, ensuring custom styles are preserved during rendering.
* Updated logic in `updateStreamingChunk` and related code paths to detect and properly handle HTML content containing `span` tags with styles, both during initial render and streaming updates. [[1]](diffhunk://#diff-65268ccd64f788a4208c0d7dadff60d32b39569f79a742cc44e62638f84ea7bcL1216-R1219) [[2]](diffhunk://#diff-65268ccd64f788a4208c0d7dadff60d32b39569f79a742cc44e62638f84ea7bcL1357-R1361) [[3]](diffhunk://#diff-65268ccd64f788a4208c0d7dadff60d32b39569f79a742cc44e62638f84ea7bcL1445-R1449)

**Version bump:**

* Increased extension version to `2.9.2` in `manifest.json` to reflect these enhancements.