### PR TITLE
Updated Gemini API and Vertex default models

### DIFF
--- a/background.js
+++ b/background.js
@@ -38,14 +38,14 @@ browser.runtime.onInstalled.addListener(function (details) {
       topK: 30,
       topP: 0.95,
       geminiApiKey: "", // Default Gemini API key (empty)
-      geminiModelId: "gemini-2.0-flash-001", // Default Gemini model
+      geminiModelId: "gemini-2.5-flash", // Default Gemini model
       geminiMaxTokens: "", // Default Gemini max output tokens (empty = use model default)
       geminiContextWindow: "", // Default Gemini context window (empty = use model default)
       geminiStream: true, // Default Gemini stream
       vertexServiceAccountKey: "", // Default Vertex service account key (empty)
       vertexLocation: "us-central1", // Default Vertex location
       vertexProjectId: "", // Default Vertex project ID (empty)
-      vertexModelId: "gemini-2.0-flash-001", // Default Vertex model
+      vertexModelId: "gemini-2.5-flash", // Default Vertex model
       vertexMaxTokens: "", // Default Vertex max output tokens (empty = use model default)
       vertexContextWindow: "", // Default Vertex context window (empty = use model default)
       vertexStream: true, // Default Vertex stream

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {  "manifest_version": 2,
   "name": "AI Webnovel Translator",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "browser_specific_settings": {
     "gecko": {
       "id": "{5be2f011-6da9-4c6f-a1ac-4c628584e78d}",

--- a/options.js
+++ b/options.js
@@ -100,11 +100,11 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('top-k').value = options.topK || '';
     document.getElementById('top-p').value = options.topP || '';
     document.getElementById('gemini-api-key').value = options.geminiApiKey || '';
-    document.getElementById('gemini-model-id').value = options.geminiModelId || 'gemini-1.5-flash-8b-latest';
+    document.getElementById('gemini-model-id').value = options.geminiModelId || 'gemini-2.5-flash';
     document.getElementById('service-account-key').value = options.vertexServiceAccountKey || '';
     document.getElementById('location').value = options.vertexLocation || 'us-central1';
     document.getElementById('project-id').value = options.vertexProjectId || '';
-    document.getElementById('model-id').value = options.vertexModelId || 'gemini-1.5-flash-002';
+    document.getElementById('model-id').value = options.vertexModelId || 'gemini-2.5-flash';
     document.getElementById('openRouter-api-key').value = options.openRouterApiKey || '';
     document.getElementById('openRouter-model-id').value = options.openRouterModelId || 'deepseek/deepseek-chat-v3-0324';
     document.getElementById('openRouter-max-tokens').value = options.openRouterMaxTokens || '';
@@ -128,12 +128,12 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('glmCoding-stream').value = options.glmCodingStream !== false ? 'true' : 'false';
 
     document.getElementById('gemini-api-key').value = options.geminiApiKey || '';
-    document.getElementById('gemini-model-id').value = options.geminiModelId || 'gemini-2.0-flash-001';
+    document.getElementById('gemini-model-id').value = options.geminiModelId || 'gemini-2.5-flash';
     document.getElementById('gemini-max-tokens').value = options.geminiMaxTokens || '';
     document.getElementById('gemini-context-window').value = options.geminiContextWindow || '';
     document.getElementById('gemini-stream').value = options.geminiStream !== false ? 'true' : 'false';
 
-    document.getElementById('model-id').value = options.vertexModelId || 'gemini-2.0-flash-001';
+    document.getElementById('model-id').value = options.vertexModelId || 'gemini-2.5-flash';
     document.getElementById('vertex-max-tokens').value = options.vertexMaxTokens || '';
     document.getElementById('vertex-context-window').value = options.vertexContextWindow || '';
     document.getElementById('vertex-stream').value = options.vertexStream !== false ? 'true' : 'false';
@@ -288,14 +288,14 @@ document.addEventListener('DOMContentLoaded', function () {
         topK: 30,
         topP: 0.95,
         geminiApiKey: "",
-        geminiModelId: "gemini-2.0-flash-001",
+        geminiModelId: "gemini-2.5-flash",
         geminiMaxTokens: "",
         geminiContextWindow: "",
         geminiStream: true,
         vertexServiceAccountKey: "",
         vertexLocation: "us-central1",
         vertexProjectId: "",
-        vertexModelId: "gemini-2.0-flash-001",
+        vertexModelId: "gemini-2.5-flash",
         vertexMaxTokens: "",
         vertexContextWindow: "",
         vertexStream: true,


### PR DESCRIPTION
Updated defaults for Gemini API and Vertex API from gemini-2.0-flash-001 to gemini-2.5-flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated default models to Gemini 2.5 Flash for both Gemini and Vertex services.
- Version bumped to 2.11.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->