### PR TITLE
Add support for novel543 site and update manifest.json

### DIFF
--- a/content.js
+++ b/content.js
@@ -57,6 +57,21 @@ function splitParagraphText(lengthinput) {
     innerDivs.forEach(div => {
       combinedContent += extractContentWithImages(div);
     });
+  } else if (document.querySelector('.content.py-5')) {
+    // novel543.com scraper: extract direct <p> children only, skipping
+    // ad blocks, VIP promos, and warnings nested inside child <div>s
+    const h1 = document.querySelector('h1');
+    if (h1?.textContent?.trim()) {
+      combinedContent += h1.textContent.trim() + '\n\n';
+    }
+    const contentEl = document.querySelector('.content.py-5');
+    const directPs = contentEl.querySelectorAll(':scope > p');
+    directPs.forEach(p => {
+      const text = p.textContent?.trim();
+      if (text) {
+        combinedContent += text + '\n\n';
+      }
+    });
   } else {
     while (paragraphId <= MAX_PARAGRAPHS) {
       let paragraphElement = document.getElementById(`p${paragraphId}`);

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "AI Webnovel Translator",
-  "version": "3.0.11",
+  "name": "AI Webnovel Translator Experimental",
+  "version": "3.0.12",
   "browser_specific_settings": {
     "gecko": {
-      "id": "{5be2f011-6da9-4c6f-a1ac-4c628584e78d}",
+      "id": "{4c5a03a4-c0a1-4978-b840-9cbd90a43e18}",
       "strict_min_version": "109.0",
       "data_collection_permissions": {
         "required": [
@@ -13,7 +13,7 @@
       }
     }
   },
-  "description": "Extracts text from Syosetsu/Kakuyomu/Booktoki/generic novel sites and translates them using Gemini, OpenRouter, OpenAI-compatible, or ChatGPT/Gemini web automation. Bring your own key.",
+  "description": "Extracts text from Syosetsu/Kakuyomu/Booktoki/novel543/generic novel sites and translates them using Gemini, OpenRouter, OpenAI-compatible, or ChatGPT/Gemini web automation. Bring your own key.",
   "permissions": [
     "activeTab",
     "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "AI Webnovel Translator Experimental",
+  "name": "AI Webnovel Translator",
   "version": "3.0.12",
   "browser_specific_settings": {
     "gecko": {
-      "id": "{4c5a03a4-c0a1-4978-b840-9cbd90a43e18}",
+      "id": "{5be2f011-6da9-4c6f-a1ac-4c628584e78d}",
       "strict_min_version": "109.0",
       "data_collection_permissions": {
         "required": [


### PR DESCRIPTION
This pull request adds support for extracting text from the novel543.com website and updates the extension metadata to reflect this new capability. The main change is a new scraping logic for novel543.com, ensuring only the relevant content is extracted while avoiding ads and promos.

**Support for novel543.com:**

* Updated `splitParagraphText` in `content.js` to add a new branch that detects novel543.com pages (`.content.py-5`) and extracts only the direct `<p>` children, skipping ad blocks and nested promos. The `<h1>` title is also included at the top of the extracted content.

**Extension metadata updates:**

* Bumped the extension version from `3.0.11` to `3.0.12` in `manifest.json`.
* Updated the extension description in `manifest.json` to mention support for novel543.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text extraction on pages with a `.content.py-5` layout, helping capture headings and paragraph content more reliably.
  * Refined supported-site wording in the extension description for a cleaner, less site-specific listing.

* **Chores**
  * Bumped the extension version to 3.0.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->